### PR TITLE
Jg 19 add item to cart auto loading

### DIFF
--- a/src/js/productDetails.mjs
+++ b/src/js/productDetails.mjs
@@ -6,7 +6,7 @@ let product = {}
 export default async function productDetails(productId) {
   product = await findProductById(productId);
   renderProductDetails(product);
- document.getElementById('addToCart').addEventListener('click', addProductToCart());
+ document.getElementById('addToCart').addEventListener('click', addProductToCart);
 }
 
 export function addProductToCart() {

--- a/src/js/productDetails.mjs
+++ b/src/js/productDetails.mjs
@@ -6,11 +6,11 @@ let product = {}
 export default async function productDetails(productId) {
   product = await findProductById(productId);
   renderProductDetails(product);
- document.getElementById('addToCart').addEventListener('click', addProductToCart());
+ document.getElementById('addToCart').addEventListener('click', addProductToCart);
 }
 
 export function addProductToCart() {
-  setLocalStorage("so-cart", product);
+  setLocalStorage('so-cart', product);
 }
 
 export function renderProductDetails() {


### PR DESCRIPTION
fix: Correct event listener for 'Add to Cart' button

The 'Add to Cart' button was incorrectly invoking the addProductToCart function immediately upon page load. This was due to the function being invoked when the event listener was added. The solution was to pass the function as a reference instead of invoking it. This ensures that the function is only called when the 'Add to Cart' button is clicked, not when the page loads. This commit closes #19.